### PR TITLE
Add User-Agent and support multi tags

### DIFF
--- a/hatena-bookmark-restful.gemspec
+++ b/hatena-bookmark-restful.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "faraday"
+  spec.add_runtime_dependency "faraday", "~> 0.10.1"
   spec.add_runtime_dependency "faraday_middleware"
   spec.add_runtime_dependency "simple_oauth"
   spec.add_development_dependency "bundler"

--- a/lib/hatena/bookmark/restful/v1.rb
+++ b/lib/hatena/bookmark/restful/v1.rb
@@ -99,11 +99,13 @@ class Hatena::Bookmark::Restful::V1
   def connection
     @connection ||= Faraday.new(url: base_uri) do |faraday|
       faraday.request :url_encoded
+      faraday.options.params_encoder = Faraday::FlatParamsEncoder
       faraday.request :oauth,
         consumer_key:    @credentials.consumer_key,
         consumer_secret: @credentials.consumer_secret,
         token:           @credentials.access_token,
         token_secret:    @credentials.access_token_secret
+      faraday.headers["User-Agent"] = "hatena-bookmark-restful"
       faraday.adapter Faraday.default_adapter
     end
   end


### PR DESCRIPTION
1. Add User-Agent  
Since Hatena's API doesn't arrow User-Agent less request, add User-Agent to request header.
2. Support multi tags  
Use Faraday's params_encoder option. This feature requires faraday's version greater than `v0.10.1`.