### PR TITLE
Use https to call Hatena's API

### DIFF
--- a/lib/hatena/bookmark/restful/v1.rb
+++ b/lib/hatena/bookmark/restful/v1.rb
@@ -13,7 +13,7 @@ module Hatena
 end
 
 class Hatena::Bookmark::Restful::V1
-  BASE_URI = 'http://api.b.hatena.ne.jp'
+  BASE_URI = 'https://api.b.hatena.ne.jp'
   API_VERSION = '1'
 
   class Credentials


### PR DESCRIPTION
以下への対応です。

[【開発者向け情報】はてなブックマークの開発者向けAPIをHTTPSに切り替え、一部エンドポイントを変更・廃止します \- はてなブックマーク開発ブログ](https://bookmark.hatenastaff.com/entry/2019/08/26/111011)	