### PR TITLE
Update cross build targeted Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ cache:
     - vendor/bundle
 language: ruby
 rvm:
-  - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - ruby-head
   - jruby-head
 bundler_args: -j4


### PR DESCRIPTION
Removed Ruby 2.1, 2.2, 2.3 and 2.4 from cross build target as they reached EOL.